### PR TITLE
feat: Allow + in enskild firma.

### DIFF
--- a/src/main/java/dev/organisationsnummer/Organisationsnummer.java
+++ b/src/main/java/dev/organisationsnummer/Organisationsnummer.java
@@ -83,6 +83,10 @@ public class Organisationsnummer implements Comparable<Organisationsnummer> {
      * @return Formatted string.
      */
     public String format(boolean separator) {
+        if (separator && this.isPersonnummer) {
+            return this.innerPersonnummer.format(false);
+        }
+
         String nr = this.getShortString();
 
         return separator ?
@@ -156,6 +160,7 @@ public class Organisationsnummer implements Comparable<Organisationsnummer> {
             throw new OrganisationsnummerException("Input value too " + (input.length() > 13 ? "long" : "short"));
         }
 
+        String originalInput = input;
         try {
             Matcher matches = regexPattern.matcher(input);
             if (!matches.find()) {
@@ -181,7 +186,7 @@ public class Organisationsnummer implements Comparable<Organisationsnummer> {
 
         } catch (OrganisationsnummerException e) {
             try {
-                this.innerPersonnummer = Personnummer.parse(input);
+                this.innerPersonnummer = Personnummer.parse(originalInput);
                 this.isPersonnummer = true;
             } catch (PersonnummerException ex) {
                 throw new OrganisationsnummerException();

--- a/src/test/java/OrganisationsnummerTest.java
+++ b/src/test/java/OrganisationsnummerTest.java
@@ -45,7 +45,7 @@ public class OrganisationsnummerTest {
     @ParameterizedTest
     @MethodSource("DataProvider#getValid")
     public void testFormatWithSeparator(OrgNrData input) throws OrganisationsnummerException {
-        assertEquals(input.longFormat, Organisationsnummer.parse(input.shortFormat).format(true));
+        assertEquals(input.longFormat.replace('+', '-'), Organisationsnummer.parse(input.shortFormat).format(true));
         assertEquals(input.longFormat, Organisationsnummer.parse(input.longFormat).format(true));
     }
 


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [X] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Fixes an issue where organisationsnummer for enskild firma with an owners age above 100 would use the `-` separator.

**Related issue**

#34 

**Motivation**

Adhere to Skatteverkets standard.

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
