### PR TITLE
Maven central publishing.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,11 @@ jobs:
         run: gradle build
       - name: Set version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Publish to GitHub Packages
-        run: gradle publish
+      - name: Publish to GitHub Packages & Maven Central
+        run: gradle publish publishToMavenCentralPortal
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenToken: ${{ secrets.MAVEN_TOKEN }}
           USERNAME: ${{ github.actor }}
           TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        java: [ 8, 11, 17, 18 ]
+        java: [ 11, 17, 21, 23 ]
     name: Java ${{ matrix.java }} test.
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java'
     id 'java-library'
     id 'signing'
+    id 'tech.yanand.maven-central-publish' version '1.3.0'
 }
 
 group 'dev.organisationsnummer'
@@ -103,4 +104,11 @@ signing {
 
 tasks.withType(Sign) {
     onlyIf { version != "NONE" }
+}
+
+mavenCentral {
+    // Docs: https://github.com/yananhub/flying-gradle-plugin
+    authToken = findProperty("mavenToken")
+    publishingType = 'AUTOMATIC'
+    maxWait = 60
 }


### PR DESCRIPTION
Added publishing to maven central: https://central.sonatype.com/namespace/dev.organisationsnummer
Made use of the following gradle plugin for now: https://github.com/yananhub/flying-gradle-plugin

Requires a release to test if it works as expected.